### PR TITLE
バリデーション修正

### DIFF
--- a/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/controller/AdminCategoryController.java
+++ b/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/controller/AdminCategoryController.java
@@ -126,7 +126,7 @@ public class AdminCategoryController {
 		List<Categories> category = categoriesMapper.find(new Categories(id));
 		
 		if (category.size() > 0) {
-			Integer itemCount = categoriesMapper.itemCount(category.get(0).getOrderNo());
+			Integer itemCount = categoriesMapper.itemCount(category.get(0).getId());
 			model.addAttribute("itemCount", itemCount);
 			model.addAttribute("category", category.get(0));
 			return "admin/categories/show";

--- a/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/mapper/CategoriesMapper.java
+++ b/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/mapper/CategoriesMapper.java
@@ -113,11 +113,11 @@ public interface CategoriesMapper {
 		}
 		
 		// 商品個数
-		public String itemCount(Long orderNo) {
+		public String itemCount(Long id) {
 			return new SQL() {{
 				SELECT("COUNT (*)");
 				FROM("products");
-				WHERE("product_category_id = " + orderNo);
+				WHERE("product_category_id = " + id);
 			}}.toString();
 		}
 		

--- a/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/service/admin/error/CategoryErrorCheckService.java
+++ b/shopping-app/src/main/java/jp/co/illmatics/apps/shopping/service/admin/error/CategoryErrorCheckService.java
@@ -21,7 +21,10 @@ public class CategoryErrorCheckService {
 		
 		List<String> errors = new ArrayList<String>();
 		
-		List<Categories> checkCategories = categoriesMapper.find(category);
+		Categories findCategory = new Categories();
+		findCategory.setOrderNo(category.getOrderNo());
+		
+		List<Categories> checkCategories = categoriesMapper.find(findCategory);
 		if (checkCategories.size() > 0 &&  Objects.nonNull(category.getOrderNo()) && category.getOrderNo() >= 0) {
 			errors.add("指定された並び順番号は既に存在します");
 		} else {


### PR DESCRIPTION
# 詳細ページ削除ボタン表示の修正
# バリデーションチェック時、既存のデータの確認で並び順番号のみで検索するように修正
- 修正前は名前と並び順番号で検索をかけてしまっていたため名前が変わると番号が被っても保存できてしまっていた。
- ご確認のほどよろしくお願いします